### PR TITLE
Fix all golangci-lint errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ycd/dstp/pkg/dstp"
 	"os"
 	"path/filepath"
+	"fmt"
 )
 
 func main() {
@@ -20,5 +21,10 @@ func main() {
 
 	ctx := context.Background()
 
-	dstp.RunAllTests(ctx, *opts)
+	err = dstp.RunAllTests(ctx, *opts)
+
+	if err != nil {
+		fmt.Print(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
At the moment GitHub lint check reports this:

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.43.0-linux-amd64/golangci-lint run --out-format=github-actions --no-config --deadline=30m --disable-all --enable=deadcode  --enable=gocyclo --enable=varcheck --enable=structcheck --enable=errcheck --enable=dupl --enable=ineffassign --enable=unconvert --enable=goconst --enable=gosec] in [] ...
  Error: Error return value of `dstp.RunAllTests` is not checked (errcheck)
```

I've fixed this error.