### PR TITLE
Fix a bug when ping won't work on Windows

### DIFF
--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -3,7 +3,6 @@ package ping
 import (
 	"context"
 	"fmt"
-	"github.com/go-ping/ping"
 	"github.com/ycd/dstp/pkg/common"
 	"strings"
 )
@@ -11,7 +10,7 @@ import (
 func RunTest(ctx context.Context, addr common.Address) (common.Output, error) {
 	var output string
 
-	pinger, err := ping.NewPinger(addr.String())
+	pinger, err := createPinger(addr.String())
 	if err != nil {
 		return "", err
 	}
@@ -39,7 +38,7 @@ func joinS(args ...string) string {
 func RunDNSTest(ctx context.Context, addr common.Address) (common.Output, error) {
 	var output string
 
-	pinger, err := ping.NewPinger(addr.String())
+	pinger, err := createPinger(addr.String())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ping/ping_unix.go
+++ b/pkg/ping/ping_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package ping
+
+import (
+	"github.com/go-ping/ping"
+)
+
+func createPinger(addr string) (*ping.Pinger, error) {
+	p, err := ping.NewPinger(addr)
+
+	return p, err
+}

--- a/pkg/ping/ping_windows.go
+++ b/pkg/ping/ping_windows.go
@@ -1,0 +1,14 @@
+package ping
+
+import (
+	"github.com/go-ping/ping"
+)
+
+func createPinger(addr string) (*ping.Pinger, error) {
+	p, err := ping.NewPinger(addr)
+
+	// https://pkg.go.dev/github.com/go-ping/ping#readme-windows
+	p.SetPrivileged(true)
+
+	return p, err
+}


### PR DESCRIPTION
At the moment `ping.go` doesn't works properly on Windows. It is means that `Ping` and `DNS` info are unavailable.

```
D:\>dstp.exe google.com                                                                                                  
Ping: failed to run ping: socket: The requested protocol has not been configured into the system, or no implementation for it exists.
DNS: failed to run ping: socket: The requested protocol has not been configured into the system, or no implementation for it exists.      
```

It doesn't works because it is not configured properly for Windows platform. See this - https://pkg.go.dev/github.com/go-ping/ping#readme-windows

This PR fixes this. Now it is works.

```
D:\>dstp.exe google.com                                                                                                  
Ping: 16.903467ms
DNS: certificate is valid for 10 days
```