### PR TITLE
Fix a bug when color won't work on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 dstp
+!dstp/
 .DS_Store

--- a/pkg/dstp/dstp.go
+++ b/pkg/dstp/dstp.go
@@ -74,7 +74,10 @@ func RunAllTests(ctx context.Context, config config.Config) error {
 		result.HTTPS = out.String()
 	}
 
-	fmt.Println(result.Output(config.Output))
+	s := result.Output(config.Output)
+	s += "\n"
+
+	printWithColor(s)
 
 	return nil
 }

--- a/pkg/dstp/dstp_unix.go
+++ b/pkg/dstp/dstp_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package dstp
+
+import (
+	"fmt"
+)
+
+func printWithColor(s string) {
+	fmt.Print(s)
+}

--- a/pkg/dstp/dstp_windows.go
+++ b/pkg/dstp/dstp_windows.go
@@ -1,0 +1,12 @@
+package dstp
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+func printWithColor(s string) {
+	// https://pkg.go.dev/github.com/fatih/color@v1.13.0#readme-insert-into-noncolor-strings-sprintfunc
+	fmt.Fprint(color.Output, s)
+}


### PR DESCRIPTION
ANSI colors not works on Windows out of the box. In order to enable it, some manipulations are required.

See - https://pkg.go.dev/github.com/fatih/color@v1.13.0#readme-insert-into-noncolor-strings-sprintfunc

At the moment this program not displays any colors but extra symbols. (Don't pay attention to unrelated output, it is for debugging purposes). With this PR colors are displayed correctly.

![SharedScreenshot](https://user-images.githubusercontent.com/20613502/140970728-39cdd200-0750-464c-a23e-79a866412254.jpg)

About `.gitignore` commit. Old version ignored all new files in `dstp` folder along with executable file named `dstp`, now it will ignore only executable file. 