### PR TITLE
Add support for expired certificates

### DIFF
--- a/pkg/dstp/dstp.go
+++ b/pkg/dstp/dstp.go
@@ -106,7 +106,7 @@ func testTLS(ctx context.Context, address common.Address) (common.Output, error)
 	if expiry > 0 {
 		output += fmt.Sprintf("certificate is valid for %v more days", expiry)
 	} else {
-		output += fmt.Sprintf("the certificate expired %v days ago", expiry)
+		output += fmt.Sprintf("the certificate expired %v days ago", -expiry)
 	}
 
 	return common.Output(output), nil

--- a/pkg/dstp/dstp.go
+++ b/pkg/dstp/dstp.go
@@ -103,7 +103,11 @@ func testTLS(ctx context.Context, address common.Address) (common.Output, error)
 	notAfter := conn.ConnectionState().PeerCertificates[0].NotAfter
 	expiresAfter := time.Until(notAfter)
 	expiry := math.Round(expiresAfter.Hours() / 24)
-	output += fmt.Sprintf("certificate is valid for %v more days", expiry)
+	if expiry > 0 {
+		output += fmt.Sprintf("certificate is valid for %v more days", expiry)
+	} else {
+		output += fmt.Sprintf("the certificate expired %v days ago", expiry)
+	}
 
 	return common.Output(output), nil
 }


### PR DESCRIPTION
When the certificate is expired is necessary to show a message that reflects that the certificate is expired and not to show that certificate will expire with negative values.