### PR TITLE
Timeout support for unresponsive targets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,13 +3,16 @@ package config
 import (
 	"flag"
 	"fmt"
-	"github.com/fatih/color"
 	"os"
+
+	"github.com/fatih/color"
 )
 
 type Config struct {
 	Addr       string
 	Output     string
+	PingCount  int
+	Timeout    int
 	ShowHelp   bool
 	Concurrent bool
 }
@@ -20,6 +23,8 @@ Options:
 	-a, --addr   <string>  The URL or the IP address to run tests against      [REQUIRED]
 	-o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext] 
 	-c           <bool>    Run all the tests concurrently.                     [Default: false]
+	-p           <int>     Number of ping packets                              [Default: 1]
+	-t           <int>     Give up on ping after this many seconds             [Default: 10s per ping packet]
 	-h, --help             Show this message and exit.
 `
 
@@ -45,6 +50,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&opts.Addr, "addr", "", "The URL or the IP address to run tests against")
 	fs.StringVar(&opts.Output, "o", "plaintext", "The type of the output")
 	fs.StringVar(&opts.Output, "out", "plaintext", "The type of the output")
+	fs.IntVar(&opts.PingCount, "p", 3, "Number of ping packets")
+	fs.IntVar(&opts.Timeout, "t", -1, "Give up on ping after this many seconds")
 	fs.BoolVar(&opts.Concurrent, "c", false, "Run all the tests concurrently")
 	fs.BoolVar(&opts.ShowHelp, "h", false, "Show help message")
 	fs.BoolVar(&opts.ShowHelp, "help", false, "Show help message")

--- a/pkg/dstp/dstp.go
+++ b/pkg/dstp/dstp.go
@@ -5,14 +5,15 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/ycd/dstp/config"
-	"github.com/ycd/dstp/pkg/common"
-	"github.com/ycd/dstp/pkg/lookup"
-	"github.com/ycd/dstp/pkg/ping"
 	"math"
 	"net/http"
 	"reflect"
 	"time"
+
+	"github.com/ycd/dstp/config"
+	"github.com/ycd/dstp/pkg/common"
+	"github.com/ycd/dstp/pkg/lookup"
+	"github.com/ycd/dstp/pkg/ping"
 )
 
 type Result struct {
@@ -50,13 +51,13 @@ func RunAllTests(ctx context.Context, config config.Config) error {
 		return err
 	}
 
-	if out, err := ping.RunTest(ctx, common.Address(addr)); err != nil {
+	if out, err := ping.RunTest(ctx, common.Address(addr), config.PingCount, config.Timeout); err != nil {
 		result.Ping = err.Error()
 	} else {
 		result.Ping = out.String()
 	}
 
-	if out, err := ping.RunDNSTest(ctx, common.Address(addr)); err != nil {
+	if out, err := ping.RunDNSTest(ctx, common.Address(addr), config.PingCount, config.Timeout); err != nil {
 		result.DNS = err.Error()
 	} else {
 		result.DNS = out.String()


### PR DESCRIPTION
Hi, nice idea :)

So, what am I trying to achieve here?

Let's talk about the `go-ping` library:

`go-ping`  will work correctly when a target is not responding, as long as a `Timeout` value was specified.

If one only specifies a `Count` and an `Interval` values, the library will not return when a target does not send response packets (typically because it is unreachable)

Under the hood, it appears that, while the library deals correctly with local ("interval") timeouts, and makes a note that all its "Count" outbound ICMP packets were sent, it still expects a matching number of reply packets before giving up. 

Therefore, I added two arguments:
- `-c` to specify an alternate attempt count (not a mandatory change!) with the default number of packets remaining `3`
- `-t` to provide a global timeout, after which dstp will consider the target "unresponsive."

If `-t` is not specified, the default timeout value is set to "a high number" multiplied by the number of ping packets. I picked 10 seconds as a high number for ping performance, therefore the default timeout would be 30 seconds to send 3 packets.