### PR TITLE
feat(dstp): implement concurrency for running tests concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Usage: dstp [OPTIONS] [ARGS]
 Options:
 	-a, --addr   <string>  The URL or the IP address to run tests against      [REQUIRED]
 	-o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext] 
-	-c           <bool>    Run all the tests concurrently.                     [Default: false]
 	-p           <int>     Number of ping packets                              [Default: 3]
 	-t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
 	-h, --help             Show this message and exit.
@@ -128,7 +127,6 @@ for 64-bit Windows, macOS, and Linux targets. They contain the compiled executab
    Options:
    -a, --addr   <string>  The URL or the IP address to run tests against      [REQUIRED]
    -o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext]
-   -c           <bool>    Run all the tests concurrently.                     [Default: false]
    -p           <int>     Number of ping packets                              [Default: 3]
    -t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
    -h, --help             Show this message and exit.

--- a/config/config.go
+++ b/config/config.go
@@ -9,12 +9,11 @@ import (
 )
 
 type Config struct {
-	Addr       string
-	Output     string
-	PingCount  int
-	Timeout    int
-	ShowHelp   bool
-	Concurrent bool
+	Addr      string
+	Output    string
+	PingCount int
+	Timeout   int
+	ShowHelp  bool
 }
 
 var usageStr = `
@@ -22,7 +21,6 @@ Usage: dstp [OPTIONS] [ARGS]
 Options:
 	-a, --addr   <string>  The URL or the IP address to run tests against      [REQUIRED]
 	-o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext] 
-	-c           <bool>    Run all the tests concurrently.                     [Default: false]
 	-p           <int>     Number of ping packets                              [Default: 3]
 	-t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
 	-h, --help             Show this message and exit.
@@ -52,7 +50,6 @@ func ConfigureOptions(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&opts.Output, "out", "plaintext", "The type of the output")
 	fs.IntVar(&opts.PingCount, "p", 3, "Number of ping packets")
 	fs.IntVar(&opts.Timeout, "t", -1, "Give up on ping after this many seconds")
-	fs.BoolVar(&opts.Concurrent, "c", false, "Run all the tests concurrently")
 	fs.BoolVar(&opts.ShowHelp, "h", false, "Show help message")
 	fs.BoolVar(&opts.ShowHelp, "help", false, "Show help message")
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,5 +1,12 @@
 package common
 
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+)
+
 type Output string
 
 type Args []string
@@ -12,4 +19,36 @@ func (o Output) String() string {
 
 func (a Address) String() string {
 	return string(a)
+}
+
+type Result struct {
+	Ping      string `json:"ping"`
+	DNS       string `json:"dns"`
+	SystemDNS string `json:"system_dns"`
+	TLS       string `json:"tls"`
+	HTTPS     string `json:"https"`
+
+	Mu sync.Mutex `json:"-"`
+}
+
+func (r Result) Output(outputType string) string {
+	var output string
+
+	switch outputType {
+	case "plaintext":
+		v := reflect.ValueOf(r)
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).Name == "Mu" {
+				continue
+			}
+
+			output += fmt.Sprintf("%s: %v\n", White(v.Type().Field(i).Name), Green(v.Field(i).Interface()))
+		}
+	case "json":
+		// SAFETY: we are sure that this never fails
+		byt, _ := json.MarshalIndent(r, "", "  ")
+		output += string(byt)
+	}
+
+	return output
 }

--- a/pkg/dstp/dstp_test.go
+++ b/pkg/dstp/dstp_test.go
@@ -15,7 +15,6 @@ func TestRunAllTests(t *testing.T) {
 		Addr:       "https://jvns.ca",
 		Output:     "plaintext",
 		ShowHelp:   false,
-		Concurrent: false,
 		Timeout:    3,
 		PingCount:  3,
 	}
@@ -24,7 +23,6 @@ func TestRunAllTests(t *testing.T) {
 		Addr:       "8.8.8.8",
 		Output:     "plaintext",
 		ShowHelp:   false,
-		Concurrent: false,
 		Timeout:    3,
 		PingCount:  3,
 	}
@@ -33,7 +31,6 @@ func TestRunAllTests(t *testing.T) {
 		Addr:       "facebook.com",
 		Output:     "plaintext",
 		ShowHelp:   false,
-		Concurrent: false,
 		Timeout:    3,
 		PingCount:  3,
 	}
@@ -42,7 +39,6 @@ func TestRunAllTests(t *testing.T) {
 		Addr:       "https://meta.stackoverflow.com/",
 		Output:     "plaintext",
 		ShowHelp:   false,
-		Concurrent: false,
 		Timeout:    3,
 		PingCount:  3,
 	}
@@ -51,7 +47,6 @@ func TestRunAllTests(t *testing.T) {
 		Addr:       "facebook.com:80",
 		Output:     "plaintext",
 		ShowHelp:   false,
-		Concurrent: false,
 		Timeout:    3,
 		PingCount:  3,
 	}

--- a/pkg/lookup/host.go
+++ b/pkg/lookup/host.go
@@ -5,15 +5,18 @@ import (
 	"github.com/ycd/dstp/pkg/common"
 	"net"
 	"strings"
+	"sync"
 )
 
-func Host(ctx context.Context, addr common.Address) (common.Output, error) {
+func Host(ctx context.Context, wg *sync.WaitGroup, addr common.Address, result *common.Result) error {
+	defer wg.Done()
+
 	addrs, err := net.LookupHost(addr.String())
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	output := "resolving " + strings.Join(addrs, ", ")
+	result.SystemDNS = "resolving " + strings.Join(addrs, ", ")
 
-	return common.Output(output), nil
+	return nil
 }

--- a/pkg/lookup/host_test.go
+++ b/pkg/lookup/host_test.go
@@ -4,16 +4,20 @@ package lookup
 
 import (
 	"context"
-	"log"
+	"github.com/ycd/dstp/pkg/common"
+	"sync"
 	"testing"
 )
 
 func TestLookup(t *testing.T) {
-	out, err := Host(context.Background(), "jvns.ca")
+	var wg sync.WaitGroup
+	var result common.Result
+	err := Host(context.Background(), &wg, "jvns.ca", &result)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	log.Println(out.String())
-
+	if result.SystemDNS == "" {
+		t.Fatal(err)
+	}
 }

--- a/pkg/lookup/host_test.go
+++ b/pkg/lookup/host_test.go
@@ -12,10 +12,12 @@ import (
 func TestLookup(t *testing.T) {
 	var wg sync.WaitGroup
 	var result common.Result
+	wg.Add(1)
 	err := Host(context.Background(), &wg, "jvns.ca", &result)
 	if err != nil {
 		t.Fatal(err)
 	}
+	wg.Wait()
 
 	if result.SystemDNS == "" {
 		t.Fatal(err)


### PR DESCRIPTION
Add concurrency for all tests by default. 

By this PR dstp becomes near 2.07x faster than the latest release.

Here is the some benchmarks that i ran using [hyperfine](https://github.com/sharkdp/hyperfine). 

```
Benchmark #1: dstp 8.8.8.8
  Time (mean ± σ):      5.259 s ±  0.146 s    [User: 64.6 ms, System: 37.2 ms]
  Range (min … max):    4.988 s …  5.452 s    10 runs
 
Benchmark #2: ./dstp 8.8.8.8
  Time (mean ± σ):      2.538 s ±  1.235 s    [User: 59.8 ms, System: 33.6 ms]
  Range (min … max):    2.126 s …  6.052 s    10 runs
```