### PR TITLE
feat: allow specifying ports for HTTPS and TLS, add timeout for TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
 	-o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext] 
 	-p           <int>     Number of ping packets                              [Default: 3]
 	-t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
+	-p           <string>  Port for testing TLS and HTTPS connectivity         [Default: 443]
 	-h, --help             Show this message and exit.
 ```
 
@@ -129,6 +130,7 @@ for 64-bit Windows, macOS, and Linux targets. They contain the compiled executab
    -o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext]
    -p           <int>     Number of ping packets                              [Default: 3]
    -t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
+   -p           <string>  Port for testing TLS and HTTPS connectivity         [Default: 443]
    -h, --help             Show this message and exit.
    ```
 

--- a/cmd/dstp/main.go
+++ b/cmd/dstp/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"github.com/ycd/dstp/config"
 	"github.com/ycd/dstp/pkg/dstp"
 	"os"
 	"path/filepath"
-	"fmt"
 )
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -14,15 +14,16 @@ type Config struct {
 	PingCount int
 	Timeout   int
 	ShowHelp  bool
+	Port      string
 }
 
-var usageStr = `
-Usage: dstp [OPTIONS] [ARGS]
+var usageStr = `Usage: dstp [OPTIONS] [ARGS]
 Options:
 	-a, --addr   <string>  The URL or the IP address to run tests against      [REQUIRED]
 	-o, --out    <string>  The type of the output, either json or plaintext    [Default: plaintext] 
 	-p           <int>     Number of ping packets                              [Default: 3]
 	-t           <int>     Give up on ping after this many seconds             [Default: 2s per ping packet]
+	-p           <string>  Port for testing TLS and HTTPS connectivity         [Default: 443]
 	-h, --help             Show this message and exit.
 `
 
@@ -48,6 +49,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string) (*Config, error) {
 	fs.StringVar(&opts.Addr, "addr", "", "The URL or the IP address to run tests against")
 	fs.StringVar(&opts.Output, "o", "plaintext", "The type of the output")
 	fs.StringVar(&opts.Output, "out", "plaintext", "The type of the output")
+	fs.StringVar(&opts.Port, "port", "", "Port for testing TLS and HTTPS connectivity")
 	fs.IntVar(&opts.PingCount, "p", 3, "Number of ping packets")
 	fs.IntVar(&opts.Timeout, "t", -1, "Give up on ping after this many seconds")
 	fs.BoolVar(&opts.ShowHelp, "h", false, "Show help message")

--- a/pkg/dstp/dstp.go
+++ b/pkg/dstp/dstp.go
@@ -25,6 +25,10 @@ func RunAllTests(ctx context.Context, config config.Config) error {
 		return err
 	}
 
+	if config.Timeout == -1 {
+		config.Timeout = 2 * config.PingCount
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(5)
 
@@ -64,6 +68,7 @@ func testTLS(ctx context.Context, wg *sync.WaitGroup, address common.Address, t 
 		result.Mu.Unlock()
 		return err
 	}
+
 	err = conn.VerifyHostname(string(address))
 	if err != nil {
 		result.Mu.Lock()

--- a/pkg/ping/dns.go
+++ b/pkg/ping/dns.go
@@ -17,11 +17,8 @@ func RunDNSTest(ctx context.Context, wg *sync.WaitGroup, addr common.Address, co
 	}
 
 	pinger.Count = count
-	if timeout == -1 {
-		pinger.Timeout = time.Duration(2*count) * time.Second
-	} else {
-		pinger.Timeout = time.Duration(timeout) * time.Second
-	}
+	pinger.Timeout = time.Duration(timeout) * time.Second
+
 	err = pinger.Run()
 	if err != nil {
 		return fmt.Errorf("failed to run ping: %v", err.Error())

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -5,14 +5,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/ycd/dstp/pkg/common"
 	"log"
 	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/ycd/dstp/pkg/common"
 )
 
 func RunTest(ctx context.Context, wg *sync.WaitGroup, addr common.Address, count int, timeout int, result *common.Result) error {
@@ -29,11 +28,8 @@ func runPing(ctx context.Context, wg *sync.WaitGroup, addr common.Address, count
 	}
 
 	pinger.Count = count
-	if timeout == -1 {
-		pinger.Timeout = time.Duration(2*count) * time.Second
-	} else {
-		pinger.Timeout = time.Duration(timeout) * time.Second
-	}
+	pinger.Timeout = time.Duration(timeout) * time.Second
+
 	err = pinger.Run()
 	if err != nil {
 		if out, err := runPingFallback(ctx, addr, count); err == nil {


### PR DESCRIPTION
Allow specifying ports for HTTPS and TLS, add timeout for TLS checking logic by using `tls.DialWithDialer()`

Fixes #26 

Signed-off-by: Yagiz Degirmenci <yagizcanilbey1903@gmail.com>